### PR TITLE
chore: Update bevy to 0.13, ordered-float to 4.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "extol_sprite_layer"
-version = "0.2.0"
+version = "0.4.0"
 edition = "2021"
 authors = ["Ash <ext0l@catgirl.ai>"]
 categories = [ "game-development" ]
@@ -16,12 +16,12 @@ default = ["parallel_y_sort"]
 parallel_y_sort = ["dep:rayon"]
 
 [dependencies]
-bevy = { version = "0.12.1", default-features = false, features = ["bevy_render", "bevy_sprite"] }
-ordered-float = "3.7.0"
+bevy = { version = "0.13.0", default-features = false, features = ["bevy_render", "bevy_sprite"] }
+ordered-float = "4.2.0"
 rayon = { version = "1.7.0", optional = true }
 
 [dev-dependencies]
-bevy = { version = "0.12.1", default-features = false, features = ["bevy_asset", "bevy_render", "bevy_sprite", "bevy_core_pipeline", "x11"] }
+bevy = { version = "0.13.0", default-features = false, features = ["bevy_asset", "bevy_render", "bevy_sprite", "bevy_core_pipeline", "x11"] }
 criterion = "0.4.0"
 fastrand = "1.9.0"
 


### PR DESCRIPTION
Update bevy to 0.13, and ordered-float to 4.2.0. Neither update requires API changes, and tests and examples appear to function as expected.